### PR TITLE
fixes viewport and zoom level for phone view

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width initial-scale=1, height=device-height, minimum-scale=1, maximum-scale=1" />
     <title>Leftover Rover</title>
     <link href='https://api.mapbox.com/mapbox-gl-js/v0.51.0/mapbox-gl.css' rel='stylesheet' />
     <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/semantic-ui@2.4.0/dist/semantic.min.css"></link>

--- a/public/style.css
+++ b/public/style.css
@@ -41,8 +41,8 @@ form div {
   z-index: 0;
   top: 0px;
   bottom: 0px;
-  left: 0px;
-  right: 0px;
+  left: 10px;
+  right: 10px;
 
   display: -webkit-box;
   display: -webkit-flex;


### PR DESCRIPTION
set new parameters for in the viewport meta tag on the index.html. This should prevent the screen for scrolling or zooming the results in not seeing page elements.

10px margins on the .map container shows the entire map while not having the buttons squished to the sides.